### PR TITLE
Add transformer for Kraken report and allows minimizer columns

### DIFF
--- a/q2_types_genomics/kraken2/__init__.py
+++ b/q2_types_genomics/kraken2/__init__.py
@@ -6,6 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import importlib
+
 from ._format import (
     Kraken2ReportFormat, Kraken2ReportDirectoryFormat,
     Kraken2OutputFormat, Kraken2OutputDirectoryFormat,
@@ -20,3 +22,5 @@ __all__ = [
     'Kraken2DBFormat', 'Kraken2DBDirectoryFormat', 'Kraken2DB',
     'BrackenDBFormat', 'BrackenDBDirectoryFormat'
 ]
+
+importlib.import_module('q2_types_genomics.kraken2._transformer')

--- a/q2_types_genomics/kraken2/_transformer.py
+++ b/q2_types_genomics/kraken2/_transformer.py
@@ -1,0 +1,19 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2023, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import pandas as pd
+
+from . import Kraken2ReportFormat
+from ..plugin_setup import plugin
+
+
+@plugin.register_transformer
+def _1(ff: Kraken2ReportFormat) -> pd.DataFrame:
+    df, cols = ff._to_dataframe()
+    df.columns = cols.keys()
+    return df


### PR DESCRIPTION
We might want the minimizer version of the report to be a different semantic type (which can use the same format). But it didn't seem super necessary at the moment, and saves us from using `TypeMap` for a bit.